### PR TITLE
chore: remove zone.js dependency

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -36,8 +36,7 @@
         "rxjs": "~7.8.1",
         "stream": "^0.0.3",
         "stream-browserify": "^3.0.0",
-        "tslib": "^2.7.0",
-        "zone.js": "~0.15.0"
+        "tslib": "^2.7.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.2.8",
@@ -16745,9 +16744,11 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
-      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA=="
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
+      "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -45,8 +45,7 @@
     "rxjs": "~7.8.1",
     "stream": "^0.0.3",
     "stream-browserify": "^3.0.0",
-    "tslib": "^2.7.0",
-    "zone.js": "~0.15.0"
+    "tslib": "^2.7.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.2.8",


### PR DESCRIPTION
It is unnecessary (comes as transient with angular/core) and the current version breaks the dep tree

Closes #57